### PR TITLE
fix build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_directories(bcDec PUBLIC ${Boost_LIBRARY_DIRS} ${PROJECT_SOURCE_DIR}
 IF( MSVC )
 add_custom_command(TARGET bcDec PRE_BUILD
 COMMAND cd /d ${PROJECT_SOURCE_DIR}/src
-COMMAND ${PROJECT_SOURCE_DIR}/src/msvcbuild.bat static
+COMMAND msvcbuild.bat static
 COMMAND cd /d ${PROJECT_SOURCE_DIR}
 )
 target_link_libraries(bcDec lua51)

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,8 @@
+@echo off
+set BOOST_ROOT=C:\Libraries\boost_1_69_0
+if not exist %BOOST_ROOT% (
+  PowerShell -file "install_boost_1.69.0_vs2015.ps1"
+)
+del CMakeCache.txt > nul 2>&1
+cmake -G"Visual Studio 14 2015" -A Win32 .
+msbuild bcDec.sln /verbosity:minimal -p:Configuration=Release

--- a/install_boost_1.69.0_vs2015.ps1
+++ b/install_boost_1.69.0_vs2015.ps1
@@ -1,0 +1,30 @@
+Write-Host "Installing boost 1.69.0..." -ForegroundColor Cyan
+
+$StopWatch = New-Object System.Diagnostics.Stopwatch
+$StopWatch.Start()
+
+New-Item 'C:\Libraries' -ItemType Directory -Force
+
+# 1.69.0
+Measure-Command {
+    Write-Host "Installing boost 1.69.0..." -ForegroundColor Cyan
+
+    Write-Host "Downloading x86..."
+    $exePath = "$env:TEMP\boost_1_69_0-msvc-14.0-32.exe"
+    (New-Object Net.WebClient).DownloadFile('https://bintray.com/boostorg/release/download_file?file_path=1.69.0%2Fbinaries%2Fboost_1_69_0-msvc-14.0-32.exe', $exePath)
+
+    Write-Host "Installing x86..."
+    cmd /c start /wait "$exePath" /verysilent
+    del $exePath
+    
+    [IO.Directory]::Move('C:\local\boost_1_69_0', 'C:\Libraries\boost_1_69_0')
+
+    Remove-Item 'C:\local' -Force -Recurse
+
+    Write-Host "Compressing..."
+
+    Start-ProcessWithOutput "compact /c /i /q /s:C:\Libraries\boost_1_69_0" -IgnoreStdOut
+}
+
+$StopWatch.Stop()
+Write-Host "Boost libraries installed in $("{0:hh}:{0:mm}:{0:ss}" -f $StopWatch.elapsed)" -ForegroundColor Green


### PR DESCRIPTION
Since the prev command already `cd` to the src folder, there's no need to include the path to exec